### PR TITLE
add require statement for use environment variable in config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 module.exports = {
   /*
   ** Headers of the page


### PR DESCRIPTION
# やったこと
- require文で.envを読むモジュールを追加してnuxt.config.jsないで環境変数を読めるようにした
    - 参考: [https://public-constructor.com/nuxt-config-js-dotenv/](https://public-constructor.com/nuxt-config-js-dotenv/)