### PR TITLE
Feature/responsible display

### DIFF
--- a/components/eventForm/EventForm.vue
+++ b/components/eventForm/EventForm.vue
@@ -158,7 +158,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .line {
   text-align: center;
 }

--- a/components/friendForm/FriendForm.vue
+++ b/components/friendForm/FriendForm.vue
@@ -16,6 +16,7 @@
     </el-form-item>
     <el-form-item>
       <el-button
+        id="friend-form-button"
         type="primary"
         @click="submitForm('friendForm')">
         送信
@@ -72,5 +73,8 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+#friend-form-button{
+  margin-top: 25px;
+}
 </style>

--- a/components/home/EventList.vue
+++ b/components/home/EventList.vue
@@ -60,5 +60,6 @@ export default {
   list-style: none;
   max-height: 100vh;
   overflow: scroll;
+  padding-left: 0;
 }
 </style>

--- a/components/home/EventList.vue
+++ b/components/home/EventList.vue
@@ -55,7 +55,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 #event-list{
   list-style: none;
   max-height: 100vh;

--- a/components/home/EventListItem.vue
+++ b/components/home/EventListItem.vue
@@ -121,7 +121,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .el-card{
   margin-top: 10px;
 }

--- a/components/home/FriendList.vue
+++ b/components/home/FriendList.vue
@@ -33,7 +33,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 #friend-list {
   max-height: 100vh;
   overflow: scroll;

--- a/components/home/FriendList.vue
+++ b/components/home/FriendList.vue
@@ -37,5 +37,6 @@ export default {
 #friend-list {
   max-height: 100vh;
   overflow: scroll;
+  padding-left: 0;
 }
 </style>

--- a/components/home/FriendListItem.vue
+++ b/components/home/FriendListItem.vue
@@ -28,7 +28,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .friend-item-name {
   font-size: x-large;
 }

--- a/components/home/MyEventList.vue
+++ b/components/home/MyEventList.vue
@@ -38,5 +38,6 @@ export default {
   list-style: none;
   max-height: 100vh;
   overflow: scroll;
+  padding-left: 0;
 }
 </style>

--- a/components/home/MyEventList.vue
+++ b/components/home/MyEventList.vue
@@ -33,7 +33,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 #my-event-list{
   list-style: none;
   max-height: 100vh;

--- a/components/profileForm/ProfileForm.vue
+++ b/components/profileForm/ProfileForm.vue
@@ -45,7 +45,6 @@ import makeAuthHeaderBody from '~/plugins/id-token'
 import * as validation from '~/util/validation'
 
 export default {
-  layout : 'AuthPage',
   data() {
     return {
       form: {

--- a/layouts/AuthPagePC.vue
+++ b/layouts/AuthPagePC.vue
@@ -1,0 +1,134 @@
+<template>
+  <el-container>
+    <el-aside width="170px">
+      <div
+        v-if="currentUser"
+        id="profile-wrapper">
+        <p id="user-name">{{ currentUser.name }}</p>
+        <p id="user-id">ID: {{ currentUser.searchID }}</p>
+      </div>
+      <el-menu>
+        <template v-if="currentUser">
+          <el-menu-item @click="toggleEventForm">
+            <i class="el-icon-dish"/>
+            <span>make meshi</span>
+          </el-menu-item>
+          <el-dialog
+            :visible.sync="eventFormVisible"
+            title="input meshi detail" >
+            <event-form @event-created="toggleEventForm"/>
+          </el-dialog>
+          <el-menu-item @click="toggleFriendForm">
+            <i class="el-icon-user"/>
+            make friend
+          </el-menu-item>
+          <el-dialog
+            :visible.sync="friendFormVisible"
+            title="input your friend's id" >
+            <friend-form @friend-created="toggleFriendForm"/>
+          </el-dialog>
+          <el-menu-item @click="userSetting">
+            <i class="el-icon-setting"/>
+            user setting
+          </el-menu-item>
+        </template>
+        <el-menu-item @click="signout">
+          <i class="el-icon-switch-button"/>
+          signout
+        </el-menu-item>
+      </el-menu>
+    </el-aside>
+    <el-main>
+      <nuxt/>
+    </el-main>
+  </el-container>
+</template>
+
+<script>
+import Vue from 'vue'
+// ElementUI
+import ElementUI from 'element-ui'
+import 'element-ui/lib/theme-chalk/index.css'
+// ElementUIでの言語設定、datePickerとかで適用される
+import locale from 'element-ui/lib/locale/lang/ja'
+
+import firebase from '../plugins/firebase'
+import FriendForm from '../components/friendForm/FriendForm'
+import EventForm from '../components/eventForm/EventForm'
+
+Vue.use(ElementUI, {locale})
+
+export default{
+  middleware: 'authorized',
+  components: {
+    EventForm,
+    FriendForm
+  },
+  data(){
+    return {
+      friendFormVisible: false,
+      eventFormVisible: false
+    }
+  },
+  computed: {
+    currentUser(){
+      return this.$store.state.profile.currentUser
+    }
+  },
+  methods: {
+    async signout(){
+      await firebase.auth().signOut().then(() => {
+        this.$store.commit('profile/clearCurrentUser', null)
+        this.$router.push('/login')
+      }).catch(() => {
+        this.$message.error('you cannot logout')
+      })
+    },
+    toggleEventForm(){
+      this.eventFormVisible = !this.eventFormVisible
+    },
+    toggleFriendForm(){
+      this.friendFormVisible = !this.friendFormVisible
+    },
+    userSetting(){
+      this.$message.success('user setting')
+    }
+  }
+}
+</script>
+
+<style scoped>
+html {
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  word-spacing: 1px;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
+}
+
+*, *:before, *:after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+.el-menu{
+  height: 80vh;
+}
+
+#user-name{
+  font-size: 24px;
+  font-weight: bold;
+}
+#user-id{
+  font-size: 18px;
+  color: #a9a9a9;
+}
+#profile-wrapper{
+  padding: 20px;
+  border-right: solid 1px #e6e6e6;
+  border-bottom: solid 1px #e6e6e6;
+}
+</style>

--- a/layouts/AuthPageSP.vue
+++ b/layouts/AuthPageSP.vue
@@ -1,43 +1,55 @@
 <template>
   <el-container>
-    <el-aside width="170px">
-      <div
-        v-if="currentUser"
-        id="profile-wrapper">
-        <p id="user-name">{{ currentUser.name }}</p>
-        <p id="user-id">ID: {{ currentUser.searchID }}</p>
-      </div>
-      <el-menu>
-        <template v-if="currentUser">
-          <el-menu-item @click="toggleEventForm">
-            <i class="el-icon-dish"/>
-            <span>make meshi</span>
+    <el-header id="app-header">
+      <div>meshireach</div>
+      <el-button 
+        icon="el-icon-menu"
+        @click="openMenu"/>
+      <el-drawer
+        id="drawer-menu"
+        :visible.sync="isDrawerOpen"
+        :direction="drawerOpenDirection"
+        size="60%">
+        <div
+          v-if="currentUser"
+          id="profile-wrapper">
+          <p id="user-name">{{ currentUser.name }}</p>
+          <p id="user-id">ID: {{ currentUser.searchID }}</p>
+        </div>
+        <el-menu>
+          <template v-if="currentUser">
+            <el-menu-item @click="toggleEventForm">
+              <i class="el-icon-dish"/>
+              <span>make meshi</span>
+            </el-menu-item>
+            <el-menu-item @click="toggleFriendForm">
+              <i class="el-icon-user"/>
+              make friend
+            </el-menu-item>
+            <el-menu-item @click="userSetting">
+              <i class="el-icon-setting"/>
+              user setting
+            </el-menu-item>
+          </template>
+          <el-menu-item @click="signout">
+            <i class="el-icon-switch-button"/>
+            signout
           </el-menu-item>
-          <el-dialog
-            :visible.sync="eventFormVisible"
-            title="input meshi detail" >
-            <event-form @event-created="toggleEventForm"/>
-          </el-dialog>
-          <el-menu-item @click="toggleFriendForm">
-            <i class="el-icon-user"/>
-            make friend
-          </el-menu-item>
-          <el-dialog
-            :visible.sync="friendFormVisible"
-            title="input your friend's id" >
-            <friend-form @friend-created="toggleFriendForm"/>
-          </el-dialog>
-          <el-menu-item @click="userSetting">
-            <i class="el-icon-setting"/>
-            user setting
-          </el-menu-item>
-        </template>
-        <el-menu-item @click="signout">
-          <i class="el-icon-switch-button"/>
-          signout
-        </el-menu-item>
-      </el-menu>
-    </el-aside>
+        </el-menu>
+      </el-drawer>
+      <el-dialog
+        :visible.sync="eventFormVisible"
+        title="input meshi detail"
+        custom-class="sp-dialog">
+        <event-form @event-created="toggleEventForm"/>
+      </el-dialog>
+      <el-dialog
+        :visible.sync="friendFormVisible"
+        title="input your friend's id"
+        custom-class="sp-dialog">
+        <friend-form @friend-created="toggleFriendForm"/>
+      </el-dialog>
+    </el-header>
     <el-main>
       <nuxt/>
     </el-main>
@@ -67,7 +79,9 @@ export default{
   data(){
     return {
       friendFormVisible: false,
-      eventFormVisible: false
+      eventFormVisible: false,
+      isDrawerOpen: false,
+      drawerOpenDirection: 'rtl'
     }
   },
   computed: {
@@ -92,12 +106,15 @@ export default{
     },
     userSetting(){
       this.$message.success('user setting')
+    },
+    openMenu(){
+      this.isDrawerOpen = true
     }
   }
 }
 </script>
 
-<style>
+<style scoped>
 html {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 16px;
@@ -114,8 +131,11 @@ html {
   margin: 0;
 }
 
-.el-menu{
-  height: 80vh;
+#app-header{
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #ccc;
 }
 
 #user-name{
@@ -127,8 +147,15 @@ html {
   color: #a9a9a9;
 }
 #profile-wrapper{
-  padding: 20px;
+  padding: 0 20px 10px 20px;
   border-right: solid 1px #e6e6e6;
   border-bottom: solid 1px #e6e6e6;
 }
+</style>
+
+<style>
+.sp-dialog{
+  min-width: 200px;
+  width: 90%;
+} 
 </style>

--- a/layouts/AuthPageSP.vue
+++ b/layouts/AuthPageSP.vue
@@ -50,7 +50,7 @@
         <friend-form @friend-created="toggleFriendForm"/>
       </el-dialog>
     </el-header>
-    <el-main>
+    <el-main id="main-container">
       <nuxt/>
     </el-main>
   </el-container>
@@ -129,6 +129,10 @@ html {
 *, *:before, *:after {
   box-sizing: border-box;
   margin: 0;
+}
+
+#main-container{
+  padding: 0;
 }
 
 #app-header{

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -43,7 +43,8 @@ module.exports = {
   modules: [
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',
-    '@nuxtjs/pwa'
+    '@nuxtjs/pwa',
+    'nuxt-device-detect'
   ],
   axios: {
     baseURL: process.env.BASE_URL

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.19.0",
     "babel-jest": "^24.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "element-ui": "^2.9.1",
+    "element-ui": "^2.12.0",
     "firebase": "^6.2.0",
     "jest": "^24.8.0",
     "lodash": "^4.17.14",
@@ -29,6 +29,7 @@
     "moment": "^2.24.0",
     "npm-run-path": "^3.1.0",
     "nuxt": "^2.0.0",
+    "nuxt-device-detect": "^1.1.5",
     "style-loader": "^0.23.1",
     "vue-jest": "^3.0.4"
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,7 +23,7 @@ import firebase from '../plugins/firebase'
 import makeAuthHeaderBody from '~/plugins/id-token'
 
 export default {
-  layout: (ctx) => ctx.isMobile ? 'AuthPageSP' : 'AuthPagePC',
+  layout: (ctx) => ctx.isMobile||ctx.isTablet ? 'AuthPageSP' : 'AuthPagePC',
   components: {
     EventList,
     FriendList,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,7 +23,7 @@ import firebase from '../plugins/firebase'
 import makeAuthHeaderBody from '~/plugins/id-token'
 
 export default {
-  layout : 'AuthPage',
+  layout: (ctx) => ctx.isMobile ? 'AuthPageSP' : 'AuthPagePC',
   components: {
     EventList,
     FriendList,

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -5,7 +5,7 @@
 <script>
 import ProfileForm from '../components/profileForm/ProfileForm.vue'
 export default {
-  layout : 'AuthPage',
+  layout: (ctx) => ctx.isMobile||ctx.isTablet ? 'AuthPageSP' : 'AuthPagePC',
   components: {
     ProfileForm
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,10 +3769,10 @@ electron-to-chromium@^1.3.137:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.146.tgz#d7010f417f87c2068fbb6700ae57767e2393eba7"
   integrity sha512-BrUq08sx7eR4PCwLbjFxXmjcbDro6DSoc1pN8VCxq76U+o9JQzJlWH/NVtcpAqcktwpE5CVvMyqHqTQfCETNoQ==
 
-element-ui@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.9.1.tgz#a05f2e76023d529ba0dfa2d03ae16e5134b20c4e"
-  integrity sha512-w8vrCW5Q+2gfDzs19MUrFdnCy5IjF98rs7DBsKnJQKFfZJZiZ2O+YAsSp/EuPrCm3P/2o/N3MtvZ34VANel13g==
+element-ui@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.12.0.tgz#a893bc11ae4f7dbb7e9d541606f23e643f131ee4"
+  integrity sha512-DapyT0PW4i/1ETPHk8K8Qbe8B6hj10+dXsRTrOTFryV9wAs6e9mCxbV65awokyR2/v/KuIHJmqX+mH3wUa4rOQ==
   dependencies:
     async-validator "~1.8.1"
     babel-helper-vue-jsx-merge-props "^2.0.0"
@@ -6979,6 +6979,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+nuxt-device-detect@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/nuxt-device-detect/-/nuxt-device-detect-1.1.5.tgz#a55d5ee5d6866186832fd411b514a974372d063e"
+  integrity sha512-m+mHMg1GgqHBNFJxtefy1MFKaVYafTskhb3QzGRGLOqwxmoFLiMlf9bbJqKM/kpqas0rXfeIO098fpNaQAK31w==
 
 nuxt@^2.0.0:
   version "2.8.1"


### PR DESCRIPTION
# やったこと
1. スマホ, タブレットでのアクセス次はスマホの画面が出るようにした
<img width="323" alt="スクリーンショット 2019-11-05 13 56 20" src="https://user-images.githubusercontent.com/38201016/68179722-51adb900-ffd4-11e9-9957-b069b0e25dc5.png">
<img width="321" alt="スクリーンショット 2019-11-05 13 56 28" src="https://user-images.githubusercontent.com/38201016/68179723-51adb900-ffd4-11e9-80c1-c635de4127ae.png">

2. コンポーネント間でcssが干渉してたので各コンポーネントのstyleタグに scopedをつけた
3. element ui のバージョンを9から12にあげた
    - 9だとdrawer menuのコンポーネントがない

## 未解決の問題
- 左上の"meshireach "がダサいけどアイコンがもらえたらそれを使おうと思っている
- element-uiのmessageがスマホサイズだと画面外にはみ出してしまう.
